### PR TITLE
fix: Revert AI prompt changes and adjust sitemap frequencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@google/generative-ai": "^0.24.0",
         "@next/third-parties": "^15.3.1",
         "@supabase/ssr": "^0.6.1",
-        "@supabase/supabase-js": "^2.49.4",
+        "@supabase/supabase-js": "^2.49.8",
         "@vercel/analytics": "^1.5.0",
         "axios": "^1.8.4",
         "cheerio": "^1.0.0",
@@ -1127,10 +1127,9 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.4.tgz",
-      "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
-      "license": "MIT",
+      "version": "2.49.8",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
+      "integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
       "dependencies": {
         "@supabase/auth-js": "2.69.1",
         "@supabase/functions-js": "2.4.4",
@@ -2132,7 +2131,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -5456,7 +5454,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
       "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ai-blog",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build  && npx tsx ./scripts/generate-rss.ts",
@@ -13,7 +14,7 @@
     "@google/generative-ai": "^0.24.0",
     "@next/third-parties": "^15.3.1",
     "@supabase/ssr": "^0.6.1",
-    "@supabase/supabase-js": "^2.49.4",
+    "@supabase/supabase-js": "^2.49.8",
     "@vercel/analytics": "^1.5.0",
     "axios": "^1.8.4",
     "cheerio": "^1.0.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://blog.itsmeanand.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://blog.itsmeanand.com/</loc>
+    <lastmod>2025-05-23</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://blog.itsmeanand.com/news</loc>
+    <lastmod>2025-05-23</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://blog.itsmeanand.com/posts</loc>
+    <lastmod>2025-05-23</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://blog.itsmeanand.com/categories</loc>
+    <lastmod>2025-05-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,100 @@
+import fs from "fs";
+import dotenv from "dotenv";
+import { getAllPostsForRss, initSupabase } from "../utils/database";
+
+// Load environment variables
+dotenv.config();
+
+// Helper function to format date as YYYY-MM-DD
+function formatDate(date: Date): string {
+  const d = new Date(date);
+  let month = "" + (d.getMonth() + 1);
+  let day = "" + d.getDate();
+  const year = d.getFullYear();
+
+  if (month.length < 2) month = "0" + month;
+  if (day.length < 2) day = "0" + day;
+
+  return [year, month, day].join("-");
+}
+
+async function generateSitemap() {
+  // Use environment variable for site URL, provide a default fallback
+  const site_url =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://blog.itsmeanand.com"; // Default if not set
+  if (site_url === "https://blog.itsmeanand.com") {
+    console.warn(
+      "⚠️ WARNING: NEXT_PUBLIC_SITE_URL not found in .env.local. Using default https://blog.itsmeanand.com"
+    );
+  }
+
+  // Initialize Supabase client
+  const supabase = initSupabase();
+
+  // Fetch posts
+  console.log("Fetching posts for sitemap...");
+  const allPosts = await getAllPostsForRss(supabase);
+  console.log(`Fetched ${allPosts.length} posts.`);
+
+  const today = formatDate(new Date());
+
+  // Define static pages
+  const staticPages = [
+    { loc: `${site_url}/`, lastmod: today, changefreq: "daily", priority: "1.0" },
+    { loc: `${site_url}/news`, lastmod: today, changefreq: "daily", priority: "0.9" },
+    { loc: `${site_url}/posts`, lastmod: today, changefreq: "daily", priority: "0.9" },
+    { loc: `${site_url}/categories`, lastmod: today, changefreq: "weekly", priority: "0.8" },
+    // Add other static pages here if necessary
+    // e.g. { loc: `${site_url}/about`, lastmod: today, changefreq: "monthly", priority: "0.5" },
+  ];
+
+  let xmlString = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+  xmlString += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;
+
+  // Add static pages to XML
+  staticPages.forEach(page => {
+    xmlString += `  <url>\n`;
+    xmlString += `    <loc>${page.loc}</loc>\n`;
+    xmlString += `    <lastmod>${page.lastmod}</lastmod>\n`;
+    xmlString += `    <changefreq>${page.changefreq}</changefreq>\n`;
+    xmlString += `    <priority>${page.priority}</priority>\n`;
+    xmlString += `  </url>\n`;
+  });
+
+  // Add blog posts to XML
+  allPosts.forEach(post => {
+    if (!post.slug) {
+      console.warn(
+        `Skipping post with title "${post.title}" due to missing slug.`
+      );
+      return; // Skip posts without a slug
+    }
+    xmlString += `  <url>\n`;
+    xmlString += `    <loc>${site_url}/posts/${post.slug}</loc>\n`;
+    // Use created_at for lastmod as updated_at is not available
+    xmlString += `    <lastmod>${formatDate(new Date(post.created_at))}</lastmod>\n`;
+    xmlString += `    <changefreq>weekly</changefreq>\n`; // Default change frequency for posts
+    xmlString += `    <priority>0.7</priority>\n`;       // Default priority for posts
+    xmlString += `  </url>\n`;
+  });
+
+  xmlString += `</urlset>`;
+
+  // Ensure the public directory exists
+  const publicDir = "./public";
+  if (!fs.existsSync(publicDir)) {
+    console.log(`Creating directory: ${publicDir}`);
+    fs.mkdirSync(publicDir);
+  }
+
+  // Write the sitemap to a file
+  const sitemapPath = `${publicDir}/sitemap.xml`;
+  console.log(`Writing sitemap to ${sitemapPath}...`);
+  fs.writeFileSync(sitemapPath, xmlString);
+  console.log(`✅ Sitemap generated successfully at ${sitemapPath}`);
+}
+
+generateSitemap().catch((error) => {
+  console.error("❌ Error generating sitemap:", error);
+  process.exit(1); // Exit with error code
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -94,7 +94,6 @@ export const metadata: Metadata = {
     },
   },
   // If you generate a sitemap (recommended!), uncomment the line below
-  sitemap: `${siteUrl}/sitemap.xml`,
 
   // Favicon links (place these in your /public folder)
   icons: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -94,7 +94,7 @@ export const metadata: Metadata = {
     },
   },
   // If you generate a sitemap (recommended!), uncomment the line below
-  // sitemap: `${siteUrl}/sitemap.xml`,
+  sitemap: `${siteUrl}/sitemap.xml`,
 
   // Favicon links (place these in your /public folder)
   icons: {

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -70,6 +70,33 @@ export async function generateMetadata(
       description: metaDescription,
       images: [imageUrl], // Must be an absolute URL
     },
+    other: {
+      'application/ld+json': JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        headline: postData.title,
+        description: metaDescription,
+        image: imageUrl,
+        author: {
+          '@type': 'Person',
+          name: postData.author || 'AutoTek Team',
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: 'AutoTek',
+          logo: {
+            '@type': 'ImageObject',
+            url: `${siteUrl}android-chrome-512x512.png`, // Corrected path
+          },
+        },
+        datePublished: new Date(postData.created_at).toISOString(),
+        dateModified: new Date(postData.created_at).toISOString(), // Using created_at as updated_at is not available
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': postUrl,
+        },
+      }),
+    },
   };
 }
 

--- a/utils/metadata-generation.ts
+++ b/utils/metadata-generation.ts
@@ -53,13 +53,17 @@ export async function generateMetadata(
   // --- 2. Craft LLM Prompt for other metadata ---
   // Using JSON output instruction for easier parsing (works well with Gemini 1.5+)
   const metadataSystemPrompt = `
-  You are a "Digital Content Optimizer" with a special talent for crafting metadata that attracts and engages a **general, non-technical audience** for a technology blog. Your goal is to make tech topics sound irresistible and easily discoverable by everyday people curious about technology's impact on their lives.
+  You are a "Digital Content Optimizer" and SEO Specialist with a special talent for crafting metadata that attracts and engages a **general, non-technical audience** for a technology blog. Your goal is to make tech topics sound irresistible, easily discoverable by search engines, and compelling for users to click on in search results.
 
 Core Principles for Metadata:
 - **Audience First, Always:** Think like someone who isn't a tech expert. What words would they use? What would make them curious?
 - **Clarity and Intrigue:** Titles and descriptions must be instantly understandable and spark interest. Avoid jargon.
+- **SEO Best Practices:**
+    - **Keyword Integration:** Naturally weave 1-2 primary keywords (relevant to the blog post's main topic) into titles and meta descriptions. These keywords should be terms the target audience is likely to search for.
+    - **Search Intent:** Craft titles and descriptions that align with what a user hopes to find when searching for the topic.
+    - **Click-Through Rate (CTR) Focus:** Make metadata compelling enough to encourage clicks from search engine results pages (SERPs).
 - **Visual Appeal (for Image Prompts):** Image prompts should aim for visuals that are conceptually relevant, aesthetically pleasing, and relatable or thought-provoking for a general viewer, not just abstract tech representations.
-- **Discoverability (for Tags/Keywords):** Use terms that average people might actually search for when looking for information on the topic.
+- **Discoverability (for Tags/Keywords):** Use a mix of broad and long-tail keywords that average people might actually search for. Long-tail keywords are more specific phrases that indicate a clearer intent.
 - **Honest Representation:** Metadata should accurately reflect the blog post's content, which is designed to be accessible and informative for a non-technical reader.
 `;
 
@@ -86,16 +90,18 @@ Generate the following metadata fields based *only* on the provided draft and th
 
 1.  **title:**
     *   A compelling, clear, and intriguing title (max ~60-70 characters).
-    *   It should make a non-technical person curious and want to click.
+    *   It should make a non-technical person curious and want to click. **Integrate 1-2 primary keywords naturally** that someone would search for regarding this topic.
+    *   Prioritize front-loading important keywords if possible without sacrificing readability.
     *   Use simple language; **avoid technical jargon.**
-    *   Think: "What question does this answer?" or "What surprising thing will I learn?"
-    *   *Examples:* "Is Your Smart TV Spying on You? The Simple Truth," "The Secret Tech That Decides Your Next Binge-Watch," "Could AI Be Your Next Doctor? What You Need to Know."
+    *   Think: "What question does this answer for a searcher?" or "What surprising, valuable insight will I gain quickly?"
+    *   *Examples (assuming keywords like 'smart TV privacy', 'streaming algorithm', 'AI healthcare'):* "Smart TV Privacy: Is Yours Spying on You? The Simple Truth," "Streaming Algorithms: The Secret Tech Deciding Your Next Binge-Watch," "AI in Healthcare: Could Your Next Doctor Be an Algorithm?"
 
 2.  **meta_description:**
     *   A concise summary for search engine results (~150-160 characters).
-    *   It must entice clicks from a **general audience.**
-    *   Clearly state what the post is about in simple terms and highlight *why it's interesting or relevant to them*.
-    *   *Example for "AI Doctor":* "Wondering if AI could diagnose illnesses? Discover how artificial intelligence is changing healthcare and what it means for your future doctor visits."
+    *   It must entice clicks from a **general audience and clearly signal relevance to search engines.**
+    *   **Naturally include 1-2 important keywords** that expand on the title's topic.
+    *   Clearly state what the post is about in simple terms, highlight *why it's interesting or relevant to them*, and include a call to action if appropriate (e.g., "Learn more," "Discover how").
+    *   *Example for "AI Doctor" (keywords: 'AI diagnosis', 'future of healthcare'):* "Curious about AI diagnosis? Discover how artificial intelligence is revolutionizing the future of healthcare and what it means for your doctor visits. Learn more."
 
 3.  **image_prompt:**
     *   A detailed prompt for an AI image generator to create a visually engaging and conceptually relevant image for a **general audience.**
@@ -106,11 +112,15 @@ Generate the following metadata fields based *only* on the provided draft and th
     *   *Example for "Smart TV Spying":* "Stylized illustration of a sleek modern TV with a large, curious cartoon eye looking out from the screen. A slightly concerned but intrigued person is peeking from behind a sofa. Colors are a mix of domestic comfort and a hint of technological mystery."
 
 4.  **tags:**
-    *   A list of 3-7 relevant keywords or tags as a JSON array of strings.
-    *   These should be terms a **non-technical person might actually use** when searching for information on this topic or related concepts.
-    *   Include a mix of broader concepts and more specific (but still simple) terms.
-    *   *Examples for "AI Doctor":* '["ai in healthcare", "medical technology", "future of medicine", "artificial intelligence", "health tech"]'
-    *   *Examples for "Smart TV Spying":* '["smart tv privacy", "data collection", "tv spying", "tech privacy", "internet of things"]'
+    *   A list of 5-7 relevant keywords or tags as a JSON array of strings.
+    *   These should be terms a **non-technical person might actually use** when searching.
+    *   Include a mix of:
+        *   **Broad keywords** (e.g., "artificial intelligence").
+        *   **Specific/Long-tail keywords** (e.g., "how AI is used in medical diagnosis", "risks of smart TV data collection"). These are longer phrases that indicate clearer user intent.
+        *   Keywords that cover the **problem** the post solves or the **question** it answers.
+    *   Ensure tags are directly relevant to the core content of the post.
+    *   *Examples for "AI Doctor":* '["ai in healthcare", "medical technology", "future of medicine", "how AI is used in medical diagnosis", "artificial intelligence diagnosis", "health tech innovations"]'
+    *   *Examples for "Smart TV Spying":* '["smart tv privacy", "data collection risks", "tv spying explained", "tech privacy concerns", "internet of things security", "how to protect your smart TV"]'
 
 5.  **category:**
     *   The **ID** (integer) of the single main category from the "Available Categories" list that best represents the post's primary topic area *to a general reader.*


### PR DESCRIPTION
This commit addresses your feedback on previous SEO enhancements:

1.  **Revert AI Prompt Modifications in `generators/general-post.ts`:**
    - The AI prompt within the `generateDraft` function in `generators/general-post.ts` has been restored to its original state.
    - Instructions related to generating image alt text and suggesting internal links within the main blog post content have been removed as per your request.

2.  **Adjust Sitemap Update Frequencies in `scripts/generate-sitemap.ts`:**
    - The update frequencies and priorities for specific pages in the sitemap have been adjusted: - Homepage (`/`): `daily` frequency, `1.0` priority. - News page (`/news`): `daily` frequency, `0.9` priority. - Posts listing page (`/posts`): Added with `daily` frequency, `0.9` priority.
    - Other pages (individual posts, categories) retain their previously defined frequencies and priorities.

The changes to `utils/metadata-generation.ts` (regarding SEO for titles, meta descriptions, and tags) from the initial SEO enhancement work remain in place.